### PR TITLE
Fix API endpoint

### DIFF
--- a/BitcoinChart/Core/api/APIConstant.swift
+++ b/BitcoinChart/Core/api/APIConstant.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 enum APIConstants {
-    static let host = "data.binance.com"
+    /// Binance moved its public API to `data-api.binance.vision`.
+    /// Update the base host so requests succeed.
+    static let host = "data-api.binance.vision"
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BitcoinChart
 **This app does not use any third-party library. The minimum Deployment target is iOS 16.0. Use Xcode 14.0 or newer to run this app.**
+
+This project fetches data from the Binance API.  Binance recently
+moved its public endpoints to the `data-api.binance.vision` domain, so
+the code has been updated to use the new host.
 <br><br><br><br>
 
 <img src="https://user-images.githubusercontent.com/33169991/236633775-476c01fc-77bb-4222-a6a4-6dddc3941b6c.png" alt="bitcoin chart" width="400">


### PR DESCRIPTION
## Summary
- switch API host to `data-api.binance.vision`
- document new Binance endpoint in README

## Testing
- `swiftc -o /tmp/main.out BitcoinChart/Core/api/APIConstant.swift && ls -l /tmp/main.out`


------
https://chatgpt.com/codex/tasks/task_e_68477b1f337c8329b2e389e3d2adf7bb