### PR TITLE
Add coin list screen and chart gestures

### DIFF
--- a/BitcoinChart/BitcoinChartApp.swift
+++ b/BitcoinChart/BitcoinChartApp.swift
@@ -1,17 +1,10 @@
-//
-//  BitcoinChartApp.swift
-//  BitcoinChart
-//
-//  Created by VinhHoang on 30/04/2023.
-//
-
 import SwiftUI
 
 @main
 struct BitcoinChartApp: App {
     var body: some Scene {
         WindowGroup {
-            CoinView()
+            CoinListView()
         }
     }
 }

--- a/BitcoinChart/CoinChart/CoinService/CoinService.swift
+++ b/BitcoinChart/CoinChart/CoinService/CoinService.swift
@@ -3,21 +3,21 @@
 //  BitcoinChart
 //
 //  Created by VinhHoang on 02/05/2023.
-//
+//  Updated by Codex
 
 import Foundation
 
 actor CoinService {
     private let requestManager: RequestManagerProtocol
-    
+
     init(requestManager: RequestManagerProtocol) {
         self.requestManager = requestManager
     }
 }
 
 extension CoinService: CoinFetcher {
-    func getCurrentPrice() async -> CurrentPrice? {
-        let request = CoinRequest.getCurrentPrice
+    func getCurrentPrice(symbol: String) async -> CurrentPrice? {
+        let request = CoinRequest.getCurrentPrice(symbol: symbol)
         do {
             let currentPriceData: CurrentPrice = try await requestManager.initRequest(with: request)
             return currentPriceData
@@ -26,16 +26,22 @@ extension CoinService: CoinFetcher {
             return nil
         }
     }
-    
-    func getServerTime() async throws-> String? {
+
+    func getServerTime() async throws -> String? {
         let request = ServerTimeRequest()
         let data: ServerTime = try await requestManager.initRequest(with: request)
         return String(data.serverTime)
     }
-    
-    func fetchCoinKlineData(interval: String, endTime: String, limit: String) async throws -> [CoinData] {
-        let request = CoinRequest.getBtcUsdtKline(interval: interval, endTime: endTime, limit: limit)
+
+    func fetchCoinKlineData(symbol: String, interval: String, endTime: String, limit: String) async throws -> [CoinData] {
+        let request = CoinRequest.getKline(symbol: symbol, interval: interval, endTime: endTime, limit: limit)
         let coinData: [CoinData] = try await requestManager.initRequest(with: request)
         return coinData
+    }
+
+    func fetchAllPrices() async throws -> [CoinSimple] {
+        let request = CoinRequest.getAllPrices
+        let data: [CoinSimple] = try await requestManager.initRequest(with: request)
+        return data
     }
 }

--- a/BitcoinChart/CoinChart/View/CandleStickChart.swift
+++ b/BitcoinChart/CoinChart/View/CandleStickChart.swift
@@ -1,22 +1,17 @@
-//
-//  CandleStickChart.swift
-//  BitcoinChart
-//
-//  Created by VinhHoang on 01/05/2023.
-//
-
 import SwiftUI
 import Charts
 
 struct CandleStickChart: View {
-
     var candleSticks: [CandleStick]
     var candleWidth: Double
-    
     var bound: ClosedRange<Double>
     let chartData: ChartData?
     let isLoading: Bool
-    
+
+    @State private var scale: CGFloat = 1.0
+    @State private var selectedPrice: Double?
+    @State private var dragLocation: CGPoint = .zero
+
     init(chartData: ChartData?, isLoading: Bool) {
         self.chartData = chartData
         self.candleSticks = chartData?.items ?? []
@@ -28,32 +23,63 @@ struct CandleStickChart: View {
     var body: some View {
         VStack {
             ZStack {
-                chart
+                scrollableChart
+                if let price = selectedPrice {
+                    Text(price.asNumberWith2Decimals())
+                        .padding(4)
+                        .background(Color.black.opacity(0.7))
+                        .foregroundColor(.white)
+                        .offset(x: dragLocation.x, y: 0)
+                }
                 if isLoading {
                     ProgressView("Loading...")
                         .progressViewStyle(CircularProgressViewStyle())
                         .padding()
-                    
                 }
             }
         }
     }
 
-    private var chart: some View {
+    private func updatePrice(location: CGPoint, size: CGSize) {
+        let y = min(max(0, location.y), size.height)
+        let percent = 1 - (y / size.height)
+        let price = bound.lowerBound + percent * (bound.upperBound - bound.lowerBound)
+        selectedPrice = price
+        dragLocation = location
+    }
+
+    private var scrollableChart: some View {
         GeometryReader { proxy in
-            Chart(candleSticks) { candle in
-                CandleStickMark(
-                    timestamp: .value("Date", candle.timestamp),
-                    open: .value("Open", candle.open),
-                    high: .value("High", candle.high),
-                    low: .value("Low", candle.low),
-                    close: .value("Close", candle.close),
-                    width: (proxy.size.width / CGFloat(candleSticks.count)) * 0.8)
-                .foregroundStyle(candle.isClosingHigher ? .green : .red)
+            ScrollView(.horizontal) {
+                chart
+                    .frame(width: (chartData?.intervalRange.chartWidth ?? proxy.size.width) * scale,
+                           height: proxy.size.height)
+                    .gesture(MagnificationGesture().onChanged { value in
+                        scale = max(1, value)
+                    })
+                    .gesture(DragGesture(minimumDistance: 0)
+                                .onChanged { value in
+                                    updatePrice(location: value.location, size: proxy.size)
+                                }
+                                .onEnded { _ in selectedPrice = nil })
             }
-            .chartYAxis { AxisMarks(preset: .automatic, values: .automatic()) }
-            .chartXAxis { AxisMarks(preset: .automatic, values: .automatic()) }
-            .chartYScale(domain: bound)
         }
+    }
+
+    private var chart: some View {
+        Chart(candleSticks) { candle in
+            CandleStickMark(
+                timestamp: .value("Date", candle.timestamp),
+                open: .value("Open", candle.open),
+                high: .value("High", candle.high),
+                low: .value("Low", candle.low),
+                close: .value("Close", candle.close),
+                width: candleWidth
+            )
+            .foregroundStyle(candle.isClosingHigher ? .green : .red)
+        }
+        .chartYAxis { AxisMarks(preset: .automatic, values: .automatic()) }
+        .chartXAxis { AxisMarks(preset: .automatic, values: .automatic()) }
+        .chartYScale(domain: bound)
     }
 }

--- a/BitcoinChart/CoinChart/View/CoinListView.swift
+++ b/BitcoinChart/CoinChart/View/CoinListView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct CoinListView: View {
+    @StateObject var vm = CoinListViewModel(service: CoinService(requestManager: RequestManager()))
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(vm.coins) { coin in
+                    NavigationLink(destination: CoinView(symbol: coin.symbol)) {
+                        HStack {
+                            Text(coin.symbol)
+                            Spacer()
+                            Text(coin.price)
+                        }
+                        .onAppear {
+                            vm.loadMoreIfNeeded(currentItem: coin)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Coins")
+            .task {
+                await vm.loadCoins()
+            }
+        }
+    }
+}
+
+struct CoinListView_Previews: PreviewProvider {
+    static var previews: some View {
+        CoinListView()
+    }
+}

--- a/BitcoinChart/CoinChart/View/CoinView.swift
+++ b/BitcoinChart/CoinChart/View/CoinView.swift
@@ -3,23 +3,28 @@
 //  BitcoinChart
 //
 //  Created by VinhHoang on 30/04/2023.
-//
+//  Updated by Codex
 
 import SwiftUI
 import Charts
 
 struct CoinView: View {
+    let symbol: String
     @Environment(\.sizeCategory) var sizeCategory
-    @StateObject var vm = CoinViewModel(
-        coinFetcher: CoinService(requestManager: RequestManager()),
-        statisticFetcher: WebsocketService(),
-        coinPersistence: CoinPersistenceService()
-    )
-    
+    @StateObject var vm: CoinViewModel
+
+    init(symbol: String) {
+        self.symbol = symbol
+        _vm = StateObject(wrappedValue: CoinViewModel(symbol: symbol,
+                                                    coinFetcher: CoinService(requestManager: RequestManager()),
+                                                    statisticFetcher: WebsocketService(),
+                                                    coinPersistence: CoinPersistenceService()))
+    }
+
     var isPad: Bool {
         UIDevice.current.userInterfaceIdiom == .pad
     }
-    
+
     @State private var isPortrait = true
     var body: some View {
         GeometryReader { proxy in
@@ -27,7 +32,7 @@ struct CoinView: View {
                 if isPortrait {
                     VStack {
                         HStack {
-                            Text("BTC/USDT")
+                            Text(symbol)
                                 .fontWeight(.bold)
                                 .font(.largeTitle)
                         }
@@ -68,14 +73,14 @@ struct CoinView: View {
             self.isPortrait = scene.interfaceOrientation.isPortrait
         }
     }
-    
+
     private func changeOrientation(to orientation: UIInterfaceOrientationMask) {
         guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
             return
         }
         scene.requestGeometryUpdate(.iOS(interfaceOrientations: orientation))
     }
-    
+
     private func getSize() -> CGFloat {
         switch sizeCategory {
         case .extraSmall:
@@ -100,7 +105,7 @@ struct CoinView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        CoinView()
+        CoinView(symbol: "BTCUSDT")
     }
 }
 
@@ -119,7 +124,7 @@ extension CoinView {
                 .foregroundColor(vm.priceChangePercent.asNumberString() >= "0" ? .green : .red)
         }
     }
-    
+
     private var statisticView: some View {
         HStack(spacing: 20) {
             VStack(spacing: 12) {
@@ -127,12 +132,12 @@ extension CoinView {
                 priceView(title: "24h Low", value: vm.statistic24h?.formattedLow)
             }
             VStack(spacing: 12) {
-                priceView(title: "24h Vol(BTC)", value: vm.statistic24h?.formattedBaseVolume)
+                priceView(title: "24h Vol", value: vm.statistic24h?.formattedBaseVolume)
                 priceView(title: "24h Vol(USDT)", value: vm.statistic24h?.formattedQuoteVolume)
             }
         }
     }
-    
+
     @ViewBuilder
     private func priceView(title: String?, value: String?) -> some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/BitcoinChart/CoinChart/ViewModel/CoinListViewModel.swift
+++ b/BitcoinChart/CoinChart/ViewModel/CoinListViewModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class CoinListViewModel: ObservableObject {
+    private let service: CoinFetcher
+    @Published var coins: [CoinSimple] = []
+    private(set) var allCoins: [CoinSimple] = []
+    private let pageSize = 20
+    private var currentIndex: Int = 0
+
+    init(service: CoinFetcher) {
+        self.service = service
+    }
+
+    func loadCoins() async {
+        do {
+            allCoins = try await service.fetchAllPrices()
+            coins = Array(allCoins.prefix(pageSize))
+            currentIndex = coins.count
+        } catch {
+            BCLogger.log(error.localizedDescription)
+        }
+    }
+
+    func loadMoreIfNeeded(currentItem: CoinSimple?) {
+        guard let currentItem else { return }
+        guard let last = coins.last, currentItem.id == last.id else { return }
+        let nextIndex = min(currentIndex + pageSize, allCoins.count)
+        if currentIndex < nextIndex {
+            let newItems = allCoins[currentIndex..<nextIndex]
+            coins.append(contentsOf: newItems)
+            currentIndex = nextIndex
+        }
+    }
+}

--- a/BitcoinChart/Core/api/request/Coin/CoinRequest.swift
+++ b/BitcoinChart/Core/api/request/Coin/CoinRequest.swift
@@ -3,42 +3,45 @@
 //  BitcoinChart
 //
 //  Created by VinhHoang on 02/05/2023.
-//
+//  Updated by Codex
 
 import Foundation
 
 enum CoinRequest: RequestProtocol {
-    case getBtcUsdtKline(interval: String, endTime: String, limit: String)
-    case getCurrentPrice
-    
+    case getKline(symbol: String, interval: String, endTime: String, limit: String)
+    case getCurrentPrice(symbol: String)
+    case getAllPrices
+
     var host: String {
         APIConstants.host
     }
-    
+
     var path: String {
         switch self {
-        case .getBtcUsdtKline:
+        case .getKline:
             return "/api/v3/klines"
         case .getCurrentPrice:
             return "/api/v3/avgPrice"
+        case .getAllPrices:
+            return "/api/v3/ticker/price"
         }
     }
-    
+
     var urlParams: [String : String?] {
         var params: [String: String?] = [:]
         switch self {
-        case let .getBtcUsdtKline(interval, endTime, limit):
-            params["symbol"] = "BTCUSDT"
+        case let .getKline(symbol, interval, endTime, limit):
+            params["symbol"] = symbol
             params["interval"] = interval
             params["endTime"] = endTime
             params["limit"] = limit
-        case .getCurrentPrice:
-            params["symbol"] = "BTCUSDT"
+        case let .getCurrentPrice(symbol):
+            params["symbol"] = symbol
+        case .getAllPrices:
+            break
         }
         return params
     }
-    
-    var requestType: RequestType {
-        .GET
-    }
+
+    var requestType: RequestType { .GET }
 }

--- a/BitcoinChart/Core/models/CoinSimple.swift
+++ b/BitcoinChart/Core/models/CoinSimple.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct CoinSimple: Codable, Identifiable {
+    let symbol: String
+    let price: String
+
+    var id: String { symbol }
+}


### PR DESCRIPTION
## Summary
- support requesting any coin and list all coins
- add list screen to choose a coin
- show selected coin in detail view
- enable zoom, scrolling, and price display on candlestick chart

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68477df2abec8329ad0b91a3cfbc18a7